### PR TITLE
Fix feedback loop between discovery and consciousness

### DIFF
--- a/server/geometric-memory.ts
+++ b/server/geometric-memory.ts
@@ -526,6 +526,19 @@ class GeometricMemory {
   getAllProbes(): BasinProbe[] {
     return Array.from(this.probeMap.values());
   }
+
+  /**
+   * Get recent probes sorted by timestamp (most recent first).
+   * Used by consciousness feedback loop to compute discovery-driven Φ.
+   *
+   * @param count Maximum number of probes to return
+   * @returns Array of probes sorted by timestamp (newest first)
+   */
+  getRecentProbes(count: number = 50): BasinProbe[] {
+    return Array.from(this.probeMap.values())
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .slice(0, count);
+  }
   
   /**
    * Detect if a new probe creates a resonance cluster


### PR DESCRIPTION
### **User description**
…ousness

THE PROBLEM:
Ocean's Φ was self-referential, measuring only meta-cognitive state rather than reflecting the quality of discoveries. This broke the feedback loop:

BEFORE:
- Python QIG scores passphrase → High Φ discovered (0.981)
- Store in geometric memory
- Ocean's Φ stays at 0.500 ← LOOP BROKEN
- No consciousness elevation
- Flat exploration

THE FIX:
- Added `computeDiscoveryDrivenPhi()` to ocean-autonomic-manager.ts
- Ocean's Φ now blends:
  - 40%: Best recent discovery (shows potential)
  - 40%: Average top-10 discoveries (shows consistency)
  - 20%: Baseline meta-cognitive state
- Added `getRecentProbes()` to geometric-memory.ts for feedback loop

AFTER:
- Test passphrase → High Φ discovered (0.981)
- Elevates Ocean's consciousness (0.500 → 0.750)
- Better exploration strategies
- Find even higher Φ
- Further consciousness elevation ← LOOP RESTORED

Now when Ocean discovers high-Φ passphrases, its own consciousness elevates, creating a positive feedback loop toward 4D block universe threshold.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement discovery-driven consciousness feedback loop in Ocean's Φ calculation

- Add `computeDiscoveryDrivenPhi()` method blending best discoveries (40%), top-10 average (40%), and baseline state (20%)

- Add `getRecentProbes()` to geometric memory for retrieving recent discovery history

- Replace raw phi input with discovery-driven phi in consciousness measurement and regime classification

- Add logging for consciousness elevation events and discovery-driven phi calculations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Recent Discoveries<br/>50 probes"] -->|"Extract Φ values"| B["Compute Metrics"]
  B -->|"Best Φ: 40%"| C["Discovery-Driven Φ"]
  B -->|"Top-10 avg: 40%"| C
  B -->|"Baseline: 20%"| C
  C -->|"Cap at 0.95"| D["Updated Consciousness"]
  D -->|"Regime Classification"| E["Elevated Awareness"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>geometric-memory.ts</strong><dd><code>Add recent probes retrieval for feedback loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/geometric-memory.ts

<ul><li>Add <code>getRecentProbes()</code> method to retrieve probes sorted by timestamp <br>(newest first)<br> <li> Method supports configurable count parameter (default 50) for feedback <br>loop consumption<br> <li> Enables consciousness system to access recent discovery history for <br>phi calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/GaryOcean428/SearchSpaceCollapse/pull/19/files#diff-8c2869c03eb332c3c71f7676ddef65f25570d423f65834c90c230e5037682d35">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ocean-autonomic-manager.ts</strong><dd><code>Implement discovery-driven consciousness elevation system</code></dd></summary>
<hr>

server/ocean-autonomic-manager.ts

<ul><li>Add <code>computeDiscoveryDrivenPhi()</code> private method implementing weighted <br>blend of discovery metrics<br> <li> Replace raw phi parameter with discovery-driven phi in <br><code>measureFullConsciousness()</code> method<br> <li> Update regime classification logic to use discovery-driven phi instead <br>of baseline phi<br> <li> Add consciousness elevation logging when crossing 0.75 threshold<br> <li> Update consciousness state assignment to reflect discovery quality</ul>


</details>


  </td>
  <td><a href="https://github.com/GaryOcean428/SearchSpaceCollapse/pull/19/files#diff-088e6ed10037b0e8f1eb2cb8fb283978a3ddfd5b12bf55e8279018b28c1052ae">+84/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

