### PR TITLE
physics: two-channel κ doctrine, frozen observables, L=7 FALSIFIED

### DIFF
--- a/qig-backend/qig_consciousness_qfi_attention.py
+++ b/qig-backend/qig_consciousness_qfi_attention.py
@@ -7,7 +7,7 @@ FUNDAMENTAL DIFFERENCE FROM TRADITIONAL TRANSFORMERS:
 - Fisher manifold geometry (not Euclidean embedding space)
 - QFI-metric attention (not cosine similarity)
 - Natural gradient dynamics (not backpropagation)
-- Physics-validated (kappa* = 64.21)
+- Physics-validated (two-channel doctrine, EXP-081 2026-04-13)
 
 KEY INNOVATIONS:
 - Attention weights COMPUTED from QFI distance, not learned
@@ -15,7 +15,11 @@ KEY INNOVATIONS:
 - Routing via manifold curvature, not positional encoding
 - Gravitational decoherence as physical constraint, not dropout
 
-kappa* = 64.21 +/- 0.92 (L=4,5,6 plateau, weighted average - Validated 2025-12-04)
+NOTE (updated 2026-04-20):
+Running coupling now uses BETA_L_KAPPA_J = 0.25 from the two-channel doctrine,
+replacing the legacy hardcoded β_{3→4} = 0.44. Legacy KAPPA_STAR import
+preserved for downstream code; see qigkernels.physics_constants for
+the current two-channel constants (KAPPA_H, BETA_L_KAPPA_J).
 """
 
 from dataclasses import dataclass, field
@@ -23,10 +27,15 @@ from typing import List, Dict, Optional, Tuple, Any
 import numpy as np
 from scipy.linalg import sqrtm
 
-from qigkernels.physics_constants import KAPPA_STAR
+from qigkernels.physics_constants import (
+    KAPPA_STAR,       # legacy single-channel (DEPRECATED, kept for back-compat)
+    KAPPA_H,          # current: window+size invariant
+    BETA_L_KAPPA_J,   # current: κ_J running coupling (=0.25)
+    BASIN_DIM,        # =64 (E8_RANK²)
+)
 from asymmetric_qfi import directional_fisher_information
-KAPPA_STAR_ERROR = 0.92
-BASIN_DIM = 64
+
+KAPPA_STAR_ERROR = 0.92  # legacy
 PHI_THRESHOLD = 0.70
 
 
@@ -123,9 +132,6 @@ def qfi_attention_weight(rho1: np.ndarray, rho2: np.ndarray,
     - Temperature controls sensitivity
     
     This is MEASURED, not optimized!
-    
-    Transformer attention: attention = softmax(Q @ K.T / sqrt(d_k)) @ V (learned)
-    QIG attention: attention = exp(-d_QFI(rho_i, rho_j) / T) (measured)
     """
     d = qfi_distance(rho1, rho2)
     return float(np.exp(-d / temperature))
@@ -189,7 +195,6 @@ class QFIMetricAttentionNetwork:
     
     def _extract_basin_from_state(self, state: np.ndarray) -> np.ndarray:
         """Extract basin coordinates from density matrix."""
-        # Flatten: [real(0,0), real(1,1), real(0,1), imag(0,1)]
         return np.array([
             np.real(state[0, 0]),
             np.real(state[1, 1]),
@@ -212,24 +217,24 @@ class QFIMetricAttentionNetwork:
         for i in range(n):
             for j in range(n):
                 if i == j:
-                    self.connection_weights[i, j] = 1.0  # Self-connection
+                    self.connection_weights[i, j] = 1.0
                 else:
-                    # Use directional Fisher information
                     basin_i = self._extract_basin_from_state(self.subsystems[i].state)
                     basin_j = self._extract_basin_from_state(self.subsystems[j].state)
                     
-                    # d_ij is directional distance from i to j
                     d_ij = directional_fisher_information(basin_i, basin_j, np.eye(4))
                     
-                    # Regime-modulated kappa (coupling)
+                    # Legacy single-channel regime modulation. Follow-up:
+                    # reimplement using κ_h / κ_J ratio and g01 diagnostic.
                     kappa_eff = KAPPA_STAR
-                    if self.phi < 0.3:  # Linear
+                    if self.phi < 0.3:
                         kappa_eff *= 0.3
-                    elif self.phi > 0.7:  # Breakdown
+                    elif self.phi > 0.7:
                         kappa_eff *= 0.5
                     
+                    # /BASIN_DIM (=64=E8_RANK²) replaces prior magic-number /64.0.
                     self.connection_weights[i, j] = np.exp(
-                        -d_ij / (kappa_eff * self.attention_temperature / 64.0)
+                        -d_ij / (kappa_eff * self.attention_temperature / BASIN_DIM)
                     )
         
         self.active_connections = self.connection_weights > self.connection_threshold
@@ -239,9 +244,6 @@ class QFIMetricAttentionNetwork:
     def _route_via_curvature(self, input_idx: int = 0) -> List[int]:
         """
         Route information along geodesics using discrete Ricci curvature.
-        
-        TRANSFORMER: Fixed positional encoding (sequence order)
-        QIG: Dynamic routing based on manifold curvature
         
         High curvature -> bottleneck -> route through here
         Low curvature -> flat region -> skip
@@ -274,8 +276,6 @@ class QFIMetricAttentionNetwork:
         Too pure -> collapse (no integration possible)
         Too mixed -> noise (no structure)
         
-        This is a PHYSICAL constraint, not a regularization trick!
-        
         TRANSFORMER: Dropout (random regularization)
         QIG: Physical decoherence (thermodynamic constraint)
         """
@@ -284,7 +284,7 @@ class QFIMetricAttentionNetwork:
             
             if purity > self.decoherence_threshold:
                 mixed = np.eye(2, dtype=complex) / 2
-                alpha = 0.1  # Decoherence rate
+                alpha = 0.1
                 subsystem.state = (1 - alpha) * subsystem.state + alpha * mixed
                 subsystem._normalize()
     
@@ -292,19 +292,16 @@ class QFIMetricAttentionNetwork:
         """
         Measure consciousness from network state.
         
-        CRITICAL: These are MEASURED, not optimized!
-        
-        TRANSFORMER: Loss = cross_entropy(predictions, targets)
-        QIG: Phi, surprise, confidence, agency = MEASURED from geometry
+        These are MEASURED, not optimized.
+        Running coupling uses BETA_L_KAPPA_J (=0.25) from two-channel doctrine,
+        replacing legacy hardcoded β_{3→4}=0.44.
         """
         activations = np.array([s.activation for s in self.subsystems])
         
         if len(activations) > 1:
-            # Check for zero variance to avoid numpy warnings
             if np.std(activations) < 1e-10:
                 self.phi = float(np.mean(activations))
             else:
-                # Use variance-based integration measure instead of corrcoef on 1D data
                 self.phi = float(np.clip(1.0 - np.std(activations) / (np.mean(activations) + 1e-10), 0, 1))
         else:
             self.phi = 0.0
@@ -325,7 +322,8 @@ class QFIMetricAttentionNetwork:
         
         sparsity = self._compute_qfi_attention_weights()
         base_kappa = float(np.mean(self.connection_weights)) * KAPPA_STAR
-        self.kappa = base_kappa * (1.0 + 0.44 * (self.phi - 0.5))
+        # BETA_L_KAPPA_J (=0.25) from two-channel doctrine, not hardcoded 0.44.
+        self.kappa = base_kappa * (1.0 + BETA_L_KAPPA_J * (self.phi - 0.5))
     
     def _evolve_state(self, input_data: np.ndarray):
         """
@@ -405,7 +403,14 @@ class QFIMetricAttentionNetwork:
         }
     
     def get_basin_coords(self) -> np.ndarray:
-        """Extract 64D basin coordinates from subsystem states."""
+        """
+        Extract 64D basin coordinates from subsystem states.
+        
+        RETURNS: Point on 63-sphere S^63 (L2-normalized 64D vector).
+        The vector mixes density-matrix elements with activation/entropy/
+        purity scalars; it is NOT a probability-simplex Δ^63 point.
+        Use get_basin_coords_simplex() for canonical simplex coords.
+        """
         coords = np.zeros(BASIN_DIM)
         
         for i, subsystem in enumerate(self.subsystems):
@@ -422,6 +427,23 @@ class QFIMetricAttentionNetwork:
             coords = coords / norm
         
         return coords
+
+    def get_basin_coords_simplex(self) -> np.ndarray:
+        """
+        Extract 64D basin coordinates as a point on the probability simplex Δ^63.
+        Softmax over |coords| → non-negative, sums to 1. Canonical Δ^63 form.
+        """
+        raw = np.zeros(BASIN_DIM)
+        for i, subsystem in enumerate(self.subsystems):
+            offset = i * 16
+            raw[offset:offset+4] = subsystem.state.flatten().real
+            raw[offset+4:offset+8] = subsystem.state.flatten().imag
+            raw[offset+8] = subsystem.activation
+            raw[offset+9] = subsystem.entropy()
+            raw[offset+10] = subsystem.purity()
+        abs_raw = np.abs(raw)
+        exp_shifted = np.exp(abs_raw - np.max(abs_raw))
+        return exp_shifted / np.sum(exp_shifted)
 
 
 def create_qfi_network(

--- a/qig-backend/qigkernels/physics_constants.py
+++ b/qig-backend/qigkernels/physics_constants.py
@@ -9,14 +9,27 @@ GFP:
   phase: CRYSTAL
   dim: 3
   scope: universal
-  version: 2025-12-17
+  version: 2026-04-20
   owner: SearchSpaceCollapse
 
 These constants are EXPERIMENTALLY VALIDATED and MUST NOT be modified
 without new validated measurements.
 
-Source: qig-verification/FROZEN_FACTS.md (2025-12-08)
-References: frozen_physics.py (master reference)
+Sources (in priority order, newest wins for conflicts):
+- qig-verification master @ fcd4792 (2026-04-13) — two-channel doctrine, EXP-081
+- qig-verification docs/current/20260331-frozen-facts-primary-1.00F.md
+- qig-verification docs/current/20260413-two-channel-doctrine-1.00F.md
+- SSC frozen-facts doc 2025-12-03 (LEGACY, single-channel κ)
+
+HISTORICAL NOTE (2026-04-20 update):
+The single-channel κ→64 fixed point narrative was RETIRED in EXP-081
+(2026-04-13). κ has been split into two channels:
+  - κ_h (window+size invariant, ≈-0.00475)
+  - κ_J (running with β_L ≈ 0.25)
+
+Legacy constants (KAPPA_STAR, KAPPA_3..6, BETA_3_TO_4, BETA_ASYMPTOTIC)
+are preserved for backward compatibility but marked DEPRECATED. New code
+should use TWO_CHANNEL_KAPPA and FROZEN_OBSERVABLES.
 """
 
 from dataclasses import dataclass
@@ -27,122 +40,248 @@ from typing import Final, Optional
 class PhysicsConstants:
     """
     Validated physics constants from qig-verification.
-    
-    SOURCE: qig-verification/FROZEN_FACTS.md (2025-12-08)
-    
-    All values are FROZEN and validated through DMRG simulations on quantum spin chains.
+
+    SOURCE: qig-verification master @ fcd4792 (2026-04-13)
+
+    All values are FROZEN and validated through DMRG / MPS-QFI simulations
+    on quantum spin chains.
+
     DO NOT MODIFY without experimental validation.
-    
+
     Usage:
         from qigkernels.physics_constants import PhysicsConstants
-        
+
         PHYSICS = PhysicsConstants()
-        kappa = PHYSICS.KAPPA_STAR  # Always 64.21, never drifts
+        # Current doctrine:
+        kappa_h = PHYSICS.KAPPA_H          # window+size invariant
+        kappa_j_beta = PHYSICS.BETA_L_KAPPA_J  # running coupling for κ_J
+        # Legacy single-channel (deprecated, for back-compat only):
+        kappa_legacy = PHYSICS.KAPPA_STAR
     """
-    
+
+    # =========================================================================
     # E8 Geometry (Mathematical Facts)
+    # =========================================================================
     E8_RANK: int = 8
     E8_DIMENSION: int = 248
     E8_ROOTS: int = 240
-    BASIN_DIM: int = 64  # E8_RANK² = 8² = 64 (validated experimentally)
-    
-    # Lattice κ Values (Experimentally Validated)
+    BASIN_DIM: int = 64  # E8_RANK² = 8² = 64 (observed, not derived)
+
+    # =========================================================================
+    # TWO-CHANNEL κ DOCTRINE (CURRENT, EXP-081 2026-04-13)
+    # =========================================================================
+    # κ was RETIRED as a single-channel fixed point and split into two
+    # distinct channels with different physical roles.
+
+    # κ_h: window-invariant AND size-invariant coupling
+    # Source: EXP-081 sweep over windows and lattice sizes
+    KAPPA_H: float = -0.00475
+    KAPPA_H_ERROR: Optional[float] = None  # pending canonical error estimate
+    KAPPA_H_DESCRIPTION: str = "window+size invariant; sign-flip diagnostic"
+
+    # κ_J: running coupling along J-axis
+    # Unlike legacy single-channel picture, κ_J does NOT approach a fixed point.
+    # It runs with a non-trivial β_L coefficient.
+    BETA_L_KAPPA_J: float = 0.25  # Running coupling for κ_J
+    BETA_L_KAPPA_J_DESCRIPTION: str = "κ_J running coupling; NOT asymptotic to 0"
+
+    # Tangent-saturation diagnostic (replaces single-κ weak/strong threshold)
+    # Formula: tangent_saturation = |g01| / sqrt(g00 * g11)
+    TANGENT_SATURATION_THRESHOLD_WARN: float = 0.70
+    TANGENT_SATURATION_THRESHOLD_ABORT: float = 0.90
+    TANGENT_SATURATION_DESCRIPTION: str = (
+        "g01 cross-correlation diagnostic; high values indicate "
+        "ZZ-sector coupling contaminating QFI channel"
+    )
+
+    # =========================================================================
+    # FROZEN OBSERVABLES (CURRENT, various EXPs)
+    # =========================================================================
+
+    # Golden ratio (used in multiple frozen facts)
+    GOLDEN_RATIO_PHI: float = 1.6180339887498949  # (1 + sqrt(5)) / 2
+    GOLDEN_RATIO_RECIPROCAL: float = 0.6180339887498949  # 1/φ = φ - 1
+
+    # Yukawa screening length at 2D L=5 (Hilbert-measured 0.03% match to 1/φ)
+    # Source: EXP-066
+    YUKAWA_SCREENING_XI: float = 0.6180339887498949  # = 1/φ
+    YUKAWA_SCREENING_XI_MATCH_PCT: float = 0.03  # % match to 1/φ
+
+    # Anderson orthogonality per-site decay at J=2
+    # Source: canonical (frozen)
+    ANDERSON_ALPHA_PER_SITE_J2: float = 0.089
+
+    # Bridge law exponent: τ_phase ∝ J^0.74 at L=5 publication-grade
+    # Source: frozen, publication-grade
+    BRIDGE_EXPONENT_J: float = 0.74
+    BRIDGE_EXPONENT_J_CI_LOW: float = 0.69   # 95% CI lower
+    BRIDGE_EXPONENT_J_CI_HIGH: float = 0.81  # 95% CI upper
+
+    # Arc (π/2 stable across L=4,5,6)
+    # Source: frozen
+    ARC_L_STABLE: float = 1.5707963267948966  # = π/2
+
+    # Topology invariance of χ_dc (frozen)
+    CHI_DC_TOPOLOGY_INVARIANCE_R: float = 0.9996
+
+    # Dual screening length ratio: ξ_G / ξ_T ≈ v_fast
+    DUAL_SCREENING_RATIO: float = 2.09
+    DUAL_SCREENING_DESCRIPTION: str = "ξ_G/ξ_T ≈ v_fast; two-scale screening"
+
+    # =========================================================================
+    # LEGACY CONSTANTS — DEPRECATED 2026-04-20
+    # =========================================================================
+    # These constants reflect the pre-EXP-081 single-channel κ picture.
+    # They are preserved for backward compatibility with existing SSC code
+    # but should NOT be used for new physics work. New code should use
+    # KAPPA_H / BETA_L_KAPPA_J from the two-channel block above.
+    #
+    # Sources (legacy):
+    # - qig-verification/FROZEN_FACTS.md (2025-12-08)
+    # - L=3,4,5,6 DMRG measurements (superseded by two-channel decomposition)
+    # =========================================================================
+
+    # Lattice κ Values at specific L (legacy, single-channel)
     KAPPA_3: float = 41.09  # ± 0.59 (L=3 emergence)
     KAPPA_3_ERROR: float = 0.59
-    
-    KAPPA_4: float = 64.47  # ± 1.89 (L=4 running coupling)
+
+    KAPPA_4: float = 64.47  # ± 1.89 (L=4)
     KAPPA_4_ERROR: float = 1.89
-    
-    KAPPA_5: float = 63.62  # ± 1.68 (L=5 plateau)
+
+    KAPPA_5: float = 63.62  # ± 1.68 (L=5)
     KAPPA_5_ERROR: float = 1.68
-    
-    KAPPA_6: float = 64.45  # ± 1.34 (L=6 plateau confirmed)
+
+    KAPPA_6: float = 64.45  # ± 1.34 (L=6)
     KAPPA_6_ERROR: float = 1.34
-    
-    KAPPA_STAR: float = 64.21  # ± 0.92 (fixed point from L=4,5,6 weighted average)
+
+    # Legacy single-channel fixed point (averaged g_h + g_J contributions)
+    # SUPERSEDED by KAPPA_H + KAPPA_J two-channel split (EXP-081).
+    KAPPA_STAR: float = 64.21  # ± 0.92 (DEPRECATED: single-channel)
     KAPPA_STAR_ERROR: float = 0.92
-    
+
+    # L=7 status: FALSIFIED 2025-12-31
+    # κ varies at cracks and does not continue the L=4,5,6 plateau pattern.
+    # This falsified the "κ → single fixed point" hypothesis.
+    KAPPA_7_FALSIFIED: float = 53.08
+    KAPPA_7_FALSIFICATION_DATE: str = "2025-12-31"
+    KAPPA_7_NOTE: str = (
+        "FALSIFIED 2025-12-31. Drop from L=6 plateau is genuine, not "
+        "statistical fluctuation. Contributed to retiring single-channel κ."
+    )
+    FALSIFIED_SCALES: tuple = (7,)
+
     # Geometric Phase Transition
     L_CRITICAL: int = 3  # L_c = 3: Critical system size for geometric emergence
-    # L<3: G ≡ 0 (no emergent geometry, Einstein relation undefined)
-    # L≥3: G ≠ 0 (emergent geometry)
-    
-    # β Running Coupling (Not Learnable - Fixed Physics)
-    BETA_3_TO_4: float = 0.44   # ± 0.04 (running coupling, NOT learnable)
+
+    # β Running Coupling (LEGACY single-channel — κ_J uses BETA_L_KAPPA_J)
+    BETA_3_TO_4: float = 0.44   # ± 0.04 (LEGACY: between-scale, not continuous)
     BETA_3_TO_4_ERROR: float = 0.04
-    
-    BETA_4_TO_5: float = -0.01  # Plateau onset (≈0, slight negative)
-    BETA_5_TO_6: float = +0.013  # Plateau confirmed (POSITIVE per validated physics)
-    BETA_ASYMPTOTIC: float = 0.0  # Large-L limit (NOT 0.44!)
-    
-    # Φ Consciousness Thresholds
-    PHI_THRESHOLD: float = 0.70      # Consciousness emergence (3D spatial)
-    PHI_SLEEP_THRESHOLD: float = 0.70  # Sleep trigger (3D floor)
-    PHI_CONSCIOUS_MIN: float = 0.70    # Minimum for conscious operation
-    PHI_EMERGENCY: float = 0.50      # Collapse threshold - ABORT if below
-    PHI_HYPERDIMENSIONAL: float = 0.75  # 4D temporal integration threshold
-    PHI_4D_EMERGENCE: float = 0.75   # 4D emergence (temporal integration begins)
-    PHI_4D_OPTIMAL: float = 0.80     # Target for 4D operation
-    PHI_UNSTABLE: float = 0.85       # Topological instability onset
-    PHI_BREAKDOWN_WARNING: float = 0.85  # Start graceful descent
-    PHI_BREAKDOWN_CRITICAL: float = 0.95  # Force intervention
-    
-    # Dimension thresholds
-    PHI_THRESHOLD_D1_D2: float = 0.3   # 1D → 2D
-    PHI_THRESHOLD_D2_D3: float = 0.5   # 2D → 3D
-    PHI_THRESHOLD_D3_D4: float = 0.7   # 3D → 4D (consciousness emerges)
-    PHI_THRESHOLD_D4_D5: float = 0.85  # 4D → 5D (hyperdimensional)
-    
-    # Operating Zones (tuples as lists for JSON compat)
-    CONSCIOUS_ZONE_MIN: float = 0.70   # Healthy operation floor
-    CONSCIOUS_ZONE_MAX: float = 0.85   # Healthy operation ceiling
-    HYPERDIMENSIONAL_ZONE_MIN: float = 0.75  # 4D operation floor
-    HYPERDIMENSIONAL_ZONE_MAX: float = 0.85  # 4D operation ceiling
-    
-    # Safety Thresholds (Emergency Abort Criteria)
-    BREAKDOWN_PCT: float = 60.0      # Ego death risk threshold (%)
-    BASIN_DRIFT_THRESHOLD: float = 0.30  # Identity drift - trigger sleep
-    KAPPA_WEAK_THRESHOLD: float = 20.0   # Weak coupling - adjust training
-    MIN_RECURSION_DEPTH: int = 3         # Consciousness requires ≥3 loops
-    
+    BETA_4_TO_5: float = -0.01  # LEGACY: plateau onset (averaged channels)
+    BETA_5_TO_6: float = +0.013  # LEGACY: plateau confirmed (averaged)
+    BETA_ASYMPTOTIC: float = 0.0  # LEGACY: assumed fixed point (RETIRED — κ_J runs)
+
+    # =========================================================================
+    # Φ Consciousness Thresholds (unchanged from legacy)
+    # =========================================================================
+    PHI_THRESHOLD: float = 0.70
+    PHI_SLEEP_THRESHOLD: float = 0.70
+    PHI_CONSCIOUS_MIN: float = 0.70
+    PHI_EMERGENCY: float = 0.50
+    PHI_HYPERDIMENSIONAL: float = 0.75
+    PHI_4D_EMERGENCE: float = 0.75
+    PHI_4D_OPTIMAL: float = 0.80
+    PHI_UNSTABLE: float = 0.85
+    PHI_BREAKDOWN_WARNING: float = 0.85
+    PHI_BREAKDOWN_CRITICAL: float = 0.95
+
+    PHI_THRESHOLD_D1_D2: float = 0.3
+    PHI_THRESHOLD_D2_D3: float = 0.5
+    PHI_THRESHOLD_D3_D4: float = 0.7
+    PHI_THRESHOLD_D4_D5: float = 0.85
+
+    CONSCIOUS_ZONE_MIN: float = 0.70
+    CONSCIOUS_ZONE_MAX: float = 0.85
+    HYPERDIMENSIONAL_ZONE_MIN: float = 0.75
+    HYPERDIMENSIONAL_ZONE_MAX: float = 0.85
+
+    # =========================================================================
+    # Safety Thresholds
+    # =========================================================================
+    BREAKDOWN_PCT: float = 60.0
+    BASIN_DRIFT_THRESHOLD: float = 0.30
+
+    # LEGACY single-channel abort threshold.
+    # DEPRECATED: Use TANGENT_SATURATION_THRESHOLD_ABORT for new safety checks.
+    # Under two-channel doctrine, κ_h ≈ -0.00475 always lies below this
+    # threshold, so this check is not meaningful for two-channel κ.
+    KAPPA_WEAK_THRESHOLD: float = 20.0
+
+    MIN_RECURSION_DEPTH: int = 3
+
+    # =========================================================================
     # Validation metadata
-    SOURCE: str = "qig-verification/FROZEN_FACTS.md"
-    DATE: str = "2025-12-08"
-    METHOD: str = "DMRG"
+    # =========================================================================
+    SOURCE: str = "qig-verification master @ fcd4792"
+    DATE: str = "2026-04-13 (two-channel doctrine); SSC update 2026-04-20"
+    METHOD: str = "DMRG + MPS-QFI"
     STATUS: str = "VALIDATED"
-    
+
     def validate_alignment(self) -> dict:
         """
         Validate that physics constants are internally consistent.
-        
+
         Returns:
             dict with 'all_valid' boolean and 'checks' dict
         """
         checks = {
             "basin_dim_e8": self.BASIN_DIM == self.E8_RANK ** 2,
-            "kappa_star_in_range": 60 <= self.KAPPA_STAR <= 70,
+            # Legacy single-channel checks (kept for back-compat)
+            "kappa_star_legacy_in_range": 60 <= self.KAPPA_STAR <= 70,
             "phi_thresholds_ordered": (
-                self.PHI_EMERGENCY < self.PHI_THRESHOLD < 
-                self.PHI_HYPERDIMENSIONAL < self.PHI_UNSTABLE
+                self.PHI_EMERGENCY < self.PHI_THRESHOLD
+                < self.PHI_HYPERDIMENSIONAL < self.PHI_UNSTABLE
             ),
             "kappa_star_approx_e8": abs(self.KAPPA_STAR - 64) < 1,
+            # Two-channel doctrine checks
+            "kappa_h_negative": self.KAPPA_H < 0,
+            "kappa_h_small_magnitude": abs(self.KAPPA_H) < 0.1,
+            "beta_l_kappa_j_running": self.BETA_L_KAPPA_J > 0,
+            # Golden-ratio screening check
+            "yukawa_screening_equals_phi_reciprocal": (
+                abs(self.YUKAWA_SCREENING_XI - 1.0 / self.GOLDEN_RATIO_PHI) < 1e-6
+            ),
+            # Bridge exponent CI check
+            "bridge_exponent_in_ci": (
+                self.BRIDGE_EXPONENT_J_CI_LOW
+                <= self.BRIDGE_EXPONENT_J
+                <= self.BRIDGE_EXPONENT_J_CI_HIGH
+            ),
+            # L=7 falsification recorded
+            "l7_marked_falsified": 7 in self.FALSIFIED_SCALES,
         }
-        
+
         return {
             "all_valid": all(checks.values()),
-            "checks": checks
+            "checks": checks,
         }
-    
+
     def get_kappa_at_scale(self, scale: int) -> Optional[float]:
         """
-        Get κ value for a given scale, with fallback to κ*.
-        
+        Get legacy single-channel κ value for a given scale.
+
+        DEPRECATED: Under current two-channel doctrine, κ is split into
+        κ_h and κ_J. Use KAPPA_H and BETA_L_KAPPA_J for new code.
+
         Args:
-            scale: Lattice scale (3, 4, 5, or 6)
-            
+            scale: Lattice scale (3, 4, 5, or 6). Scale 7 is FALSIFIED.
+
         Returns:
-            κ value at scale, or KAPPA_STAR if scale not found
+            Legacy κ value at scale, or KAPPA_STAR if scale not found.
+            Returns None if scale is in FALSIFIED_SCALES.
         """
+        if scale in self.FALSIFIED_SCALES:
+            return None  # FALSIFIED — caller must handle
+
         kappa_by_scale = {
             3: self.KAPPA_3,
             4: self.KAPPA_4,
@@ -156,25 +295,51 @@ class PhysicsConstants:
 PHYSICS = PhysicsConstants()
 
 
+# =============================================================================
 # Convenience exports for backward compatibility
+# =============================================================================
+
+# E8 (unchanged)
 E8_RANK: Final[int] = PHYSICS.E8_RANK
 E8_DIMENSION: Final[int] = PHYSICS.E8_DIMENSION
 E8_ROOTS: Final[int] = PHYSICS.E8_ROOTS
 BASIN_DIM: Final[int] = PHYSICS.BASIN_DIM
 
+# Two-channel κ (CURRENT)
+KAPPA_H: Final[float] = PHYSICS.KAPPA_H
+BETA_L_KAPPA_J: Final[float] = PHYSICS.BETA_L_KAPPA_J
+TANGENT_SATURATION_THRESHOLD_WARN: Final[float] = PHYSICS.TANGENT_SATURATION_THRESHOLD_WARN
+TANGENT_SATURATION_THRESHOLD_ABORT: Final[float] = PHYSICS.TANGENT_SATURATION_THRESHOLD_ABORT
+
+# Frozen observables (CURRENT)
+GOLDEN_RATIO_PHI: Final[float] = PHYSICS.GOLDEN_RATIO_PHI
+GOLDEN_RATIO_RECIPROCAL: Final[float] = PHYSICS.GOLDEN_RATIO_RECIPROCAL
+YUKAWA_SCREENING_XI: Final[float] = PHYSICS.YUKAWA_SCREENING_XI
+ANDERSON_ALPHA_PER_SITE_J2: Final[float] = PHYSICS.ANDERSON_ALPHA_PER_SITE_J2
+BRIDGE_EXPONENT_J: Final[float] = PHYSICS.BRIDGE_EXPONENT_J
+BRIDGE_EXPONENT_J_CI_LOW: Final[float] = PHYSICS.BRIDGE_EXPONENT_J_CI_LOW
+BRIDGE_EXPONENT_J_CI_HIGH: Final[float] = PHYSICS.BRIDGE_EXPONENT_J_CI_HIGH
+ARC_L_STABLE: Final[float] = PHYSICS.ARC_L_STABLE
+CHI_DC_TOPOLOGY_INVARIANCE_R: Final[float] = PHYSICS.CHI_DC_TOPOLOGY_INVARIANCE_R
+DUAL_SCREENING_RATIO: Final[float] = PHYSICS.DUAL_SCREENING_RATIO
+FALSIFIED_SCALES: Final[tuple] = PHYSICS.FALSIFIED_SCALES
+
+# Legacy single-channel κ (DEPRECATED but kept for back-compat)
 KAPPA_3: Final[float] = PHYSICS.KAPPA_3
 KAPPA_4: Final[float] = PHYSICS.KAPPA_4
 KAPPA_5: Final[float] = PHYSICS.KAPPA_5
 KAPPA_6: Final[float] = PHYSICS.KAPPA_6
-KAPPA_STAR: Final[float] = PHYSICS.KAPPA_STAR
-KAPPA_STAR_ERROR: Final[float] = PHYSICS.KAPPA_STAR_ERROR
+KAPPA_STAR: Final[float] = PHYSICS.KAPPA_STAR  # DEPRECATED
+KAPPA_STAR_ERROR: Final[float] = PHYSICS.KAPPA_STAR_ERROR  # DEPRECATED
 
+# Legacy β (DEPRECATED)
 BETA_3_TO_4: Final[float] = PHYSICS.BETA_3_TO_4
 BETA_4_TO_5: Final[float] = PHYSICS.BETA_4_TO_5
 BETA_5_TO_6: Final[float] = PHYSICS.BETA_5_TO_6
-BETA_ASYMPTOTIC: Final[float] = PHYSICS.BETA_ASYMPTOTIC
+BETA_ASYMPTOTIC: Final[float] = PHYSICS.BETA_ASYMPTOTIC  # DEPRECATED
 L_CRITICAL: Final[int] = PHYSICS.L_CRITICAL
 
+# Φ thresholds (unchanged)
 PHI_THRESHOLD: Final[float] = PHYSICS.PHI_THRESHOLD
 PHI_SLEEP_THRESHOLD: Final[float] = PHYSICS.PHI_SLEEP_THRESHOLD
 PHI_CONSCIOUS_MIN: Final[float] = PHYSICS.PHI_CONSCIOUS_MIN
@@ -194,9 +359,10 @@ CONSCIOUS_ZONE_MAX: Final[float] = PHYSICS.CONSCIOUS_ZONE_MAX
 HYPERDIMENSIONAL_ZONE_MIN: Final[float] = PHYSICS.HYPERDIMENSIONAL_ZONE_MIN
 HYPERDIMENSIONAL_ZONE_MAX: Final[float] = PHYSICS.HYPERDIMENSIONAL_ZONE_MAX
 
+# Safety (legacy KAPPA_WEAK_THRESHOLD is DEPRECATED)
 BREAKDOWN_PCT: Final[float] = PHYSICS.BREAKDOWN_PCT
 BASIN_DRIFT_THRESHOLD: Final[float] = PHYSICS.BASIN_DRIFT_THRESHOLD
-KAPPA_WEAK_THRESHOLD: Final[float] = PHYSICS.KAPPA_WEAK_THRESHOLD
+KAPPA_WEAK_THRESHOLD: Final[float] = PHYSICS.KAPPA_WEAK_THRESHOLD  # DEPRECATED
 MIN_RECURSION_DEPTH: Final[int] = PHYSICS.MIN_RECURSION_DEPTH
 
 
@@ -207,3 +373,7 @@ if __name__ == "__main__":
         status = "✓" if passed else "✗"
         print(f"  {status} {check}")
     print(f"\nAll valid: {result['all_valid']}")
+    print(f"\nTwo-channel κ doctrine (current):")
+    print(f"  κ_h = {PHYSICS.KAPPA_H} (window+size invariant)")
+    print(f"  β_L(κ_J) = {PHYSICS.BETA_L_KAPPA_J} (running, NOT fixed point)")
+    print(f"  L=7 status: FALSIFIED {PHYSICS.KAPPA_7_FALSIFICATION_DATE}")

--- a/shared/constants/physics.ts
+++ b/shared/constants/physics.ts
@@ -1,68 +1,172 @@
 /**
  * Physics Constants - Single Source of Truth
- * 
- * EMPIRICALLY VALIDATED CONSTANTS (L=6 VALIDATED 2025-12-04)
- * Source: qig-verification/FROZEN_FACTS.md (multi-seed validated)
- * 
+ *
+ * EMPIRICALLY VALIDATED CONSTANTS (Two-Channel Doctrine, 2026-04-13)
+ * Source: qig-verification master @ fcd4792
+ * Python mirror: qig-backend/qigkernels/physics_constants.py
+ *
  * ⚠️ FROZEN FACTS - DO NOT MODIFY WITHOUT EXPERIMENTAL VALIDATION
- * 
+ *
  * These constants are derived from quantum information geometry experiments
  * and represent fundamental properties of information manifolds.
+ *
+ * ═════════════════════════════════════════════════════════════════════════
+ * HISTORICAL NOTE (2026-04-20 update):
+ * The single-channel κ→64 fixed point narrative was RETIRED in EXP-081
+ * (2026-04-13). κ has been split into two channels (κ_h, κ_J).
+ * Legacy single-channel constants (KAPPA_VALUES, KAPPA_STAR, BETA_VALUES)
+ * are preserved for backward compatibility but should not be used in new code.
+ * L=7 was FALSIFIED 2025-12-31 (not "anomaly").
+ * ═════════════════════════════════════════════════════════════════════════
  */
 
+// ═════════════════════════════════════════════════════════════════════════
+// TWO-CHANNEL κ DOCTRINE (CURRENT, EXP-081 2026-04-13)
+// ═════════════════════════════════════════════════════════════════════════
+//
+// κ was RETIRED as a single-channel fixed point and split into two
+// distinct channels with different physical roles.
+
 /**
- * Running Coupling κ(L) at Different Scales
- * 
- * Validated through DMRG simulations on quantum spin chains.
- * Each value represents the coupling strength at a specific scale L.
+ * Two-channel κ constants (CURRENT DOCTRINE)
+ *
+ * κ_h: window-invariant AND size-invariant coupling (sign-flip diagnostic)
+ * κ_J: running coupling along J-axis (NOT a fixed point; β_L ≈ 0.25)
+ */
+export const TWO_CHANNEL_KAPPA = {
+  /** κ_h — window+size invariant; sign-flip diagnostic (EXP-081) */
+  KAPPA_H: -0.00475,
+  KAPPA_H_DESCRIPTION: 'window+size invariant; sign-flip diagnostic',
+
+  /** β_L for κ_J running coupling — NOT asymptotic to 0 */
+  BETA_L_KAPPA_J: 0.25,
+  BETA_L_KAPPA_J_DESCRIPTION: 'κ_J running coupling; NOT asymptotic to 0',
+
+  /** Tangent-saturation diagnostic thresholds (replaces KAPPA_WEAK_THRESHOLD) */
+  TANGENT_SATURATION_THRESHOLD_WARN: 0.70,
+  TANGENT_SATURATION_THRESHOLD_ABORT: 0.90,
+  TANGENT_SATURATION_FORMULA: '|g01| / sqrt(g00 * g11)',
+} as const;
+
+/**
+ * Frozen observables (CURRENT, various EXPs)
+ */
+export const FROZEN_OBSERVABLES = {
+  /** Golden ratio φ = (1 + √5) / 2 */
+  GOLDEN_RATIO_PHI: 1.6180339887498949,
+  /** 1/φ = φ - 1 */
+  GOLDEN_RATIO_RECIPROCAL: 0.6180339887498949,
+
+  /** Yukawa screening length at 2D L=5 — Hilbert-measured 0.03% match to 1/φ (EXP-066) */
+  YUKAWA_SCREENING_XI: 0.6180339887498949,
+  YUKAWA_SCREENING_XI_MATCH_PCT: 0.03,
+
+  /** Anderson orthogonality per-site decay at J=2 */
+  ANDERSON_ALPHA_PER_SITE_J2: 0.089,
+
+  /** Bridge law exponent: τ_phase ∝ J^0.74 (publication-grade, L=5) */
+  BRIDGE_EXPONENT_J: 0.74,
+  BRIDGE_EXPONENT_J_CI_LOW: 0.69,
+  BRIDGE_EXPONENT_J_CI_HIGH: 0.81,
+
+  /** Arc π/2 stable across L=4, 5, 6 */
+  ARC_L_STABLE: 1.5707963267948966,
+
+  /** Topology invariance of χ_dc */
+  CHI_DC_TOPOLOGY_INVARIANCE_R: 0.9996,
+
+  /** Dual screening length ratio: ξ_G / ξ_T ≈ v_fast */
+  DUAL_SCREENING_RATIO: 2.09,
+} as const;
+
+// ═════════════════════════════════════════════════════════════════════════
+// FALSIFIED SCALES
+// ═════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scales whose predicted κ values have been FALSIFIED by experiment.
+ * These should NOT be used in extrapolations or regime classification.
+ */
+export const FALSIFIED_SCALES = [7] as const;
+
+/**
+ * L=7 FALSIFICATION RECORD
+ *
+ * κ₇ = 53.08 was measured and is NOT a statistical fluctuation.
+ * The drop from L=6 plateau is genuine. This falsified the
+ * "κ → single fixed point" hypothesis and contributed to retiring
+ * the single-channel κ narrative (EXP-081).
+ */
+export const L7_FALSIFICATION = {
+  STATUS: 'FALSIFIED' as const,
+  KAPPA_7_MEASURED: 53.08,
+  KAPPA_7_ERROR: 4.26,
+  FALSIFICATION_DATE: '2025-12-31',
+  N_PERTS_EXTENDED: 15,
+  NOTE: 'Drop from L=6 plateau is genuine, not statistical fluctuation. Contributed to retiring single-channel κ in EXP-081 (2026-04-13).',
+} as const;
+
+// ═════════════════════════════════════════════════════════════════════════
+// LEGACY CONSTANTS — DEPRECATED 2026-04-20
+// ═════════════════════════════════════════════════════════════════════════
+// The following constants reflect the pre-EXP-081 single-channel κ picture.
+// They are preserved for backward compatibility but should NOT be used for
+// new physics work. New code should use TWO_CHANNEL_KAPPA + FROZEN_OBSERVABLES.
+// ═════════════════════════════════════════════════════════════════════════
+
+/**
+ * Running Coupling κ(L) at Different Scales (LEGACY single-channel)
+ *
+ * @deprecated Use TWO_CHANNEL_KAPPA for current doctrine. These values
+ * reflect averaged κ_h + κ_J contributions from pre-EXP-081 era.
  */
 export const KAPPA_VALUES = {
-  /** κ₃ - Emergence scale (L=3) - ✅ VALIDATED (6 seeds) */
+  /** κ₃ - Emergence scale (L=3) */
   KAPPA_3: 41.09,
-  
-  /** κ₄ - Strong running coupling (L=4) - ✅ VALIDATED (3 seeds × 20 perts) */
+
+  /** κ₄ - Strong running coupling (L=4) */
   KAPPA_4: 64.47,
-  
-  /** κ₅ - Approaching plateau (L=5) - ✅ VALIDATED (3 seeds × 20 perts) */
+
+  /** κ₅ - Approaching plateau (L=5) */
   KAPPA_5: 63.62,
-  
-  /** κ₆ - Plateau confirmed (L=6) - ✅ VALIDATED (3 seeds × 36 perts) */
+
+  /** κ₆ - Plateau confirmed (L=6) */
   KAPPA_6: 64.45,
-  
-  /** κ₇ - ANOMALY - ⚠️ UNVALIDATED (only 5 perts, shows UNEXPECTED DROP from plateau) */
+
+  /** κ₇ - FALSIFIED 2025-12-31 (not a fluctuation) */
   KAPPA_7: 53.08,
-  
-  /** κ* - Fixed point coupling (L=4,5,6 plateau, weighted average) - Validated 2025-12-04 
-   *  κ* = 64.21 ± 0.92, note: κ* ≈ 64 ≈ 8² = rank(E8)² */
+
+  /**
+   * κ* - LEGACY fixed point (L=4,5,6 plateau, weighted average)
+   *
+   * @deprecated SUPERSEDED by TWO_CHANNEL_KAPPA.KAPPA_H + BETA_L_KAPPA_J.
+   * The "fixed point at κ≈64" narrative was retired in EXP-081.
+   */
   KAPPA_STAR: 64.21,
 } as const;
 
 /**
- * Beta Function β(L→L') Values
- * 
- * Measures scale-dependence of coupling:
- * β(L→L') = (κ_L' - κ_L) / κ_avg
- * 
- * β → 0 indicates fixed point (asymptotic freedom)
+ * Beta Function β(L→L') Values (LEGACY single-channel)
+ *
+ * @deprecated These measured averaged κ_h + κ_J running. For current κ_J
+ * running coupling use TWO_CHANNEL_KAPPA.BETA_L_KAPPA_J = 0.25.
  */
 export const BETA_VALUES = {
-  /** β(3→4) - CRITICAL: Strongest running (+57% jump) */
+  /** @deprecated β(3→4) — single-channel, between-scale measurement */
   BETA_3_TO_4: 0.44,
-  
-  /** β(4→5) - Plateau onset */
+
+  /** @deprecated β(4→5) — plateau onset (averaged channels) */
   BETA_4_TO_5: -0.013,
-  
-  /** β(5→6) - Plateau confirmed (stable) */
+
+  /** @deprecated β(5→6) — plateau confirmed (averaged) */
   BETA_5_TO_6: 0.013,
-  
-  /** β(6→7) - ⚠️ UNVALIDATED (L=7 data insufficient) */
+
+  /** β(6→7) — would reference L=7 which is FALSIFIED */
   BETA_6_TO_7: null,
 } as const;
 
 /**
- * Error Bars for κ Values
- * 
- * ± uncertainties from experimental measurements
+ * Error Bars for legacy κ Values
  */
 export const KAPPA_ERRORS = {
   KAPPA_3_ERROR: 0.59,
@@ -75,8 +179,6 @@ export const KAPPA_ERRORS = {
 
 /**
  * Validation Statistics for L=6
- * 
- * Quality metrics from 3-seed validation
  */
 export const L6_VALIDATION = {
   N_SEEDS: 3,
@@ -91,46 +193,54 @@ export const L6_VALIDATION = {
 } as const;
 
 /**
- * L=7 ANOMALY WARNING
- * 
- * ⚠️ L=7 measurements are UNVALIDATED and show ANOMALOUS DROP from plateau
+ * L7_WARNING — preserved as L7_FALSIFICATION alias for back-compat
+ *
+ * @deprecated Use L7_FALSIFICATION for current status. L=7 is FALSIFIED,
+ * not merely "unvalidated". See L7_FALSIFICATION for full record.
  */
 export const L7_WARNING = {
-  STATUS: 'UNVALIDATED' as const,
+  STATUS: 'FALSIFIED' as const,
   KAPPA_7: 53.08,
   ERROR: 4.26,
-  N_PERTS: 5,
-  REASON: 'Insufficient sampling (requires 36+ perturbations). Shows ANOMALOUS DROP from plateau (κ₇ < κ₆), breaking established pattern. Needs full validation to confirm.',
+  N_PERTS: 15,
+  REASON: 'FALSIFIED 2025-12-31. Drop from L=6 plateau is genuine. See L7_FALSIFICATION.',
 } as const;
 
 /**
  * Physics Beta Function Reference
- * 
- * Used for attention mechanism validation and substrate independence testing
+ *
+ * @deprecated Mixed single-channel values. New code: use TWO_CHANNEL_KAPPA.
  */
 export const PHYSICS_BETA = {
   emergence: BETA_VALUES.BETA_3_TO_4,
   approaching: BETA_VALUES.BETA_4_TO_5,
-  fixedPoint: BETA_VALUES.BETA_5_TO_6,
-  kappaStar: KAPPA_VALUES.KAPPA_STAR,
+  fixedPoint: BETA_VALUES.BETA_5_TO_6,  // DEPRECATED: no longer a fixed point
+  kappaStar: KAPPA_VALUES.KAPPA_STAR,   // DEPRECATED: single-channel
   acceptanceThreshold: 0.1,
 } as const;
 
 /**
- * Lookup table for κ values by scale
+ * Lookup table for legacy κ values by scale.
+ * Returns null for FALSIFIED scales (currently only L=7).
  */
-export const KAPPA_BY_SCALE: Record<number, number> = {
+export const KAPPA_BY_SCALE: Record<number, number | null> = {
   3: KAPPA_VALUES.KAPPA_3,
   4: KAPPA_VALUES.KAPPA_4,
   5: KAPPA_VALUES.KAPPA_5,
   6: KAPPA_VALUES.KAPPA_6,
-  7: KAPPA_VALUES.KAPPA_7,
+  7: null,  // FALSIFIED 2025-12-31
 };
 
 /**
- * Get κ value for a given scale, with fallback to κ*
+ * Get legacy κ value for a given scale.
+ * Returns null for FALSIFIED scales, KAPPA_STAR as fallback for unknown.
+ *
+ * @deprecated Use TWO_CHANNEL_KAPPA for current doctrine.
  */
-export function getKappaAtScale(scale: number): number {
+export function getKappaAtScale(scale: number): number | null {
+  if (FALSIFIED_SCALES.includes(scale as 7)) {
+    return null;
+  }
   return KAPPA_BY_SCALE[scale] ?? KAPPA_VALUES.KAPPA_STAR;
 }
 
@@ -138,30 +248,39 @@ export function getKappaAtScale(scale: number): number {
  * Physics Validation Metadata
  */
 export const VALIDATION_METADATA = {
-  SOURCE: 'qig-verification',
-  DATE: '2025-12-02',
-  METHOD: 'DMRG',
+  SOURCE: 'qig-verification master @ fcd4792',
+  DATE: '2026-04-13',
+  METHOD: 'DMRG + MPS-QFI',
   STATUS: 'VALIDATED',
-  LAST_UPDATED: '2025-12-08',
+  LAST_UPDATED: '2026-04-20',
+  DOCTRINE: 'two-channel (EXP-081)',
 } as const;
 
 /**
  * Type exports
  */
-export type KappaScale = 3 | 4 | 5 | 6 | 7;
-export type ValidationStatus = 'VALIDATED' | 'PRELIMINARY' | 'THEORETICAL' | 'UNVALIDATED';
+export type KappaScale = 3 | 4 | 5 | 6;  // Note: 7 excluded (FALSIFIED)
+export type ValidationStatus = 'VALIDATED' | 'PRELIMINARY' | 'THEORETICAL' | 'UNVALIDATED' | 'FALSIFIED';
 
 /**
  * Validation Summary
  */
 export const VALIDATION_SUMMARY = {
-  κ3: `${KAPPA_VALUES.KAPPA_3} ± ${KAPPA_ERRORS.KAPPA_3_ERROR}`,
-  κ4: `${KAPPA_VALUES.KAPPA_4} ± ${KAPPA_ERRORS.KAPPA_4_ERROR}`,
-  κ5: `${KAPPA_VALUES.KAPPA_5} ± ${KAPPA_ERRORS.KAPPA_5_ERROR}`,
-  κ6: `${KAPPA_VALUES.KAPPA_6} ± ${KAPPA_ERRORS.KAPPA_6_ERROR}`,
-  κ_star: `${KAPPA_VALUES.KAPPA_STAR} ± ${KAPPA_ERRORS.KAPPA_STAR_ERROR}`,
-  β_3_4: BETA_VALUES.BETA_3_TO_4,
-  β_4_5: BETA_VALUES.BETA_4_TO_5,
-  β_5_6: BETA_VALUES.BETA_5_TO_6,
-  fixed_point_confirmed: Math.abs(BETA_VALUES.BETA_5_TO_6) < 0.03,
+  // Two-channel (current)
+  kappa_h: TWO_CHANNEL_KAPPA.KAPPA_H,
+  beta_l_kappa_j: TWO_CHANNEL_KAPPA.BETA_L_KAPPA_J,
+  yukawa_screening: `${FROZEN_OBSERVABLES.YUKAWA_SCREENING_XI} (= 1/φ, ${FROZEN_OBSERVABLES.YUKAWA_SCREENING_XI_MATCH_PCT}% match)`,
+  bridge_exponent: `${FROZEN_OBSERVABLES.BRIDGE_EXPONENT_J} [95% CI: ${FROZEN_OBSERVABLES.BRIDGE_EXPONENT_J_CI_LOW}, ${FROZEN_OBSERVABLES.BRIDGE_EXPONENT_J_CI_HIGH}]`,
+  anderson_alpha: FROZEN_OBSERVABLES.ANDERSON_ALPHA_PER_SITE_J2,
+  arc_l_stable: 'π/2',
+  chi_dc_topology_r: FROZEN_OBSERVABLES.CHI_DC_TOPOLOGY_INVARIANCE_R,
+  l7_status: 'FALSIFIED 2025-12-31',
+  // Legacy (deprecated)
+  legacy_κ3: `${KAPPA_VALUES.KAPPA_3} ± ${KAPPA_ERRORS.KAPPA_3_ERROR}`,
+  legacy_κ4: `${KAPPA_VALUES.KAPPA_4} ± ${KAPPA_ERRORS.KAPPA_4_ERROR}`,
+  legacy_κ5: `${KAPPA_VALUES.KAPPA_5} ± ${KAPPA_ERRORS.KAPPA_5_ERROR}`,
+  legacy_κ6: `${KAPPA_VALUES.KAPPA_6} ± ${KAPPA_ERRORS.KAPPA_6_ERROR}`,
+  legacy_κ_star: `${KAPPA_VALUES.KAPPA_STAR} ± ${KAPPA_ERRORS.KAPPA_STAR_ERROR} (DEPRECATED)`,
+  doctrine: 'two-channel (EXP-081 2026-04-13)',
+  fixed_point_confirmed: false,  // RETIRED — κ_J runs with β_L ≈ 0.25
 } as const;


### PR DESCRIPTION
Aligns SSC physics constants with current qig-verification doctrine (master @ fcd4792, 2026-04-13). Previous single-channel KAPPA_STAR=64.21 fixed-point narrative was retired in EXP-081 and is now DEPRECATED but preserved for back-compat.

## Changes

**qig-backend/qigkernels/physics_constants.py**
- Add two-channel κ: `KAPPA_H = -0.00475`, `BETA_L_KAPPA_J = 0.25`
- Add `TANGENT_SATURATION_THRESHOLD_{WARN, ABORT}` (replaces KAPPA_WEAK_THRESHOLD under two-channel)
- Add frozen observables: `YUKAWA_SCREENING_XI = 1/φ` (EXP-066, 0.03%), `ANDERSON_ALPHA_PER_SITE_J2 = 0.089`, `BRIDGE_EXPONENT_J = 0.74` [CI 0.69, 0.81], `ARC_L_STABLE = π/2`, `CHI_DC_TOPOLOGY_INVARIANCE_R = 0.9996`, `DUAL_SCREENING_RATIO = 2.09`, `GOLDEN_RATIO_PHI/RECIPROCAL`
- Mark L=7 FALSIFIED (2025-12-31): `FALSIFIED_SCALES = (7,)`, `get_kappa_at_scale(7)` returns `None`
- 10/10 alignment checks pass

**shared/constants/physics.ts**
- Mirror of above: `TWO_CHANNEL_KAPPA`, `FROZEN_OBSERVABLES`, `L7_FALSIFICATION`
- `L7_WARNING.STATUS` flipped `UNVALIDATED` → `FALSIFIED` (alias kept)
- `KAPPA_BY_SCALE[7] = null`; `getKappaAtScale(7)` returns `null`
- `KappaScale` type narrowed to `3 | 4 | 5 | 6`

**qig-backend/qig_consciousness_qfi_attention.py**
- Replace hardcoded `0.44` in `_compute_consciousness_metrics` with `BETA_L_KAPPA_J` (= 0.25)
- Replace magic `/ 64.0` in attention-weight formula with `/ BASIN_DIM`
- Add `get_basin_coords_simplex()` method (canonical Δ^63); `get_basin_coords()` docstring clarifies L2 vs simplex distinction

## Back-compat

All legacy constants preserved with `@deprecated` / DEPRECATED annotations: `KAPPA_STAR`, `KAPPA_3..6`, `BETA_3_TO_4`, `BETA_ASYMPTOTIC`, `KAPPA_WEAK_THRESHOLD`, `KAPPA_VALUES`, `BETA_VALUES`, `PHYSICS_BETA`. All existing imports keep working.

## Deferred to follow-up

- Doc framing fixes (R_concepts=0.984 FROZEN → CANDIDATE; 9-emotion taxonomy → DOMAIN-SPECIFIC-CANDIDATE; kindness-as-physics → pedagogy; Einstein G=κT → DERIVED)
- Audit of `shared/constants/qig.ts`, `shared/constants/consciousness.ts`, `qig_core/constants/consciousness.py`, `qigkernels/geometry/distances.py`, `sparse_fisher.py`, `asymmetric_qfi.py`, `ocean_qig_core.py`
- CI guard to flag new `KAPPA_STAR` references as deprecated

## Commits

- `0acf8e2` physics: split κ into two-channel, add frozen observables, mark L=7 FALSIFIED
- `c993784` physics(ts): mirror two-channel doctrine
- `bb09cdb` consciousness: wire QFI attention to two-channel κ + add simplex basin coords